### PR TITLE
Fix crash when converting chart with SvgString on CLI

### DIFF
--- a/OngekiFumenEditor/Base/EditorObjects/Svg/SvgStringPrefab.cs
+++ b/OngekiFumenEditor/Base/EditorObjects/Svg/SvgStringPrefab.cs
@@ -84,7 +84,7 @@ namespace OngekiFumenEditor.Base.EditorObjects.Svg
 			brush.Freeze();
 			var pen = new Pen(brush, 1);
 			pen.Freeze();
-			var dpiInfo = VisualTreeHelper.GetDpi(Application.Current.MainWindow);
+			var dpiInfo = Application.Current.MainWindow is not null ? VisualTreeHelper.GetDpi(Application.Current.MainWindow) : new();
 
 			var direction = ContentFlowDirection switch
 			{


### PR DESCRIPTION
Running `OngekiFumenEditor.exe convert` on a file with an SvgString on the CLI causes an error because there is no MainWindow object.