### PR TITLE
Localize "文档还有没保存的变更,是否立即保存?" (save before quit) prompt and show file name

### DIFF
--- a/OngekiFumenEditor/Modules/FumenVisualEditor/ViewModels/FumenVisualEditorViewModel.cs
+++ b/OngekiFumenEditor/Modules/FumenVisualEditor/ViewModels/FumenVisualEditorViewModel.cs
@@ -304,6 +304,32 @@ namespace OngekiFumenEditor.Modules.FumenVisualEditor.ViewModels
             }
         }
 
+        public override async Task<bool> CanCloseAsync(CancellationToken cancellationToken)
+        {
+            if (!IsDirty)
+                return true;
+
+            var result = MessageBox.Show(
+                Resources.SaveBeforeClosingPrompt.Format(FileName),
+                FileName,
+                MessageBoxButton.YesNoCancel,
+                MessageBoxImage.Warning,
+                MessageBoxResult.Cancel);
+
+            switch (result)
+            {
+                case MessageBoxResult.Yes:
+                    if (IsNew)
+                        return await DoSaveAs(this);
+                    await Save(FilePath);
+                    return true;
+                case MessageBoxResult.No:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
         #endregion
 
         #region Activation

--- a/OngekiFumenEditor/Properties/Resources.Designer.cs
+++ b/OngekiFumenEditor/Properties/Resources.Designer.cs
@@ -4352,7 +4352,16 @@ namespace OngekiFumenEditor.Properties {
                 return ResourceManager.GetString("Save", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   查找类似 Save changes to &quot;{0}&quot; before closing? 的本地化字符串。
+        /// </summary>
+        public static string SaveBeforeClosingPrompt {
+            get {
+                return ResourceManager.GetString("SaveBeforeClosingPrompt", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Record up to  的本地化字符串。
         /// </summary>

--- a/OngekiFumenEditor/Properties/Resources.ja.resx
+++ b/OngekiFumenEditor/Properties/Resources.ja.resx
@@ -1597,4 +1597,7 @@
   <data name="CurvePrecisionLabel" xml:space="preserve">
     <value>CurvePrecision</value>
   </data>
+  <data name="SaveBeforeClosingPrompt" xml:space="preserve">
+    <value>閉じる前に変更された"{0}" を保存しますか？</value>
+  </data>
 </root>

--- a/OngekiFumenEditor/Properties/Resources.resx
+++ b/OngekiFumenEditor/Properties/Resources.resx
@@ -1866,4 +1866,7 @@
   <data name="ProgramUpdates" xml:space="preserve">
     <value>Program Updates</value>
   </data>
+  <data name="SaveBeforeClosingPrompt" xml:space="preserve">
+    <value>Save changes to "{0}" before closing?</value>
+  </data>
 </root>


### PR DESCRIPTION
Example:
![image](https://github.com/user-attachments/assets/0f4e8957-a39d-41cc-afe6-8a1507aac8b7)

Since it adds a `{0}` to the Resources, I cannot copy over the zh string, sorry