### PR TITLE
[OGKR Export] Fix buggy LBK when zero-length walls are present

### DIFF
--- a/OngekiFumenEditor/Base/GridRange.cs
+++ b/OngekiFumenEditor/Base/GridRange.cs
@@ -5,6 +5,9 @@
 		public GridBase Min { get; set; }
 		public GridBase Max { get; set; }
 
+		public GridOffset Distance =>
+			Max - Min;
+
 		public bool IsInRange(GridBase chk, bool includeEdge = true)
 		{
 			return includeEdge ? (Min <= chk && chk <= Max) : (Min < chk && chk < Max);

--- a/OngekiFumenEditor/Base/OngekiObjects/LaneBlockArea.cs
+++ b/OngekiFumenEditor/Base/OngekiObjects/LaneBlockArea.cs
@@ -89,7 +89,8 @@ namespace OngekiFumenEditor.Base.OngekiObjects
 			var blockStartTGrid = TGrid;
 			var blockEndTGrid = EndIndicator.TGrid;
 
-			var lanes = fumen.Lanes.Where(x => x.LaneType == wallType).OrderBy(x => x.TGrid).ToList();
+			var lanes = fumen.Lanes.Where(x => x.LaneType == wallType && x.GetTGridRange().Distance != GridOffset.Zero)
+				.OrderBy(x => x.TGrid).ToList();
 
 			var startWallLane = lanes.LastOrDefault(x => x.TGrid <= blockStartTGrid);
 			var endWallLane = startWallLane != null && startWallLane.GetTGridRange().Max >= blockEndTGrid


### PR DESCRIPTION
Fixes a bug in export where incorrect XGrid gets written to LBK when the LBK comes after a zero-length wall, like this:
<img width="1076" height="776" alt="image" src="https://github.com/user-attachments/assets/6c911396-ff4a-43fe-a366-17a6c0f28523" />
