### PR TITLE
nyageki: fix invalid .nyageki output with null bullet palette

### DIFF
--- a/OngekiFumenEditor/Parser/DefaultImpl/Nyageki/DefaultNyagekiFumenFormatter.cs
+++ b/OngekiFumenEditor/Parser/DefaultImpl/Nyageki/DefaultNyagekiFumenFormatter.cs
@@ -302,7 +302,7 @@ namespace OngekiFumenEditor.Parser.DefaultImpl.Nyageki
                     sb.Write($", SizeValue[{bullet.SizeValue}]");
                     sb.Write($", ShooterValue[{bullet.ShooterValue}]");
                     sb.Write($", TargetValue[{bullet.TargetValue}]");
-                    sb.WriteLine($", Speed[{bullet.Speed}]");
+                    sb.WriteLine();
                 }
             }
             sb.WriteLine();


### PR DESCRIPTION
`Speed` was printed twice which caused failure on fumen open