### PR TITLE
editor: improve lane selection operations

### DIFF
--- a/OngekiFumenEditor/Modules/FumenVisualEditor/Converters/KeyBindingToTextConverter.cs
+++ b/OngekiFumenEditor/Modules/FumenVisualEditor/Converters/KeyBindingToTextConverter.cs
@@ -1,0 +1,20 @@
+using OngekiFumenEditor.Kernel.KeyBinding;
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace OngekiFumenEditor.Modules.FumenVisualEditor.Converters
+{
+	public class KeyBindingToTextConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			return value is KeyBindingDefinition kb ? KeyBindingDefinition.FormatToExpression(kb) : string.Empty;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/OngekiFumenEditor/Modules/FumenVisualEditor/KeyBindingDefinitions.cs
+++ b/OngekiFumenEditor/Modules/FumenVisualEditor/KeyBindingDefinitions.cs
@@ -108,6 +108,18 @@ namespace OngekiFumenEditor.Modules.FumenVisualEditor
              Key.F);
 
         [Export]
+        //        [Gesture Shift+E] = [Action MenuItemAction_SelectEntireLane];
+        public static KeyBindingDefinition KBD_SelectEntireLane = new KeyBindingDefinition(
+            "kbd_editor_SelectEntireLane",
+             ModifierKeys.Shift, Key.E);
+
+        [Export]
+        //        [Gesture Shift+V] = [Action MenuItemAction_SelectAttachedCurves];
+        public static KeyBindingDefinition KBD_SelectAttachedCurves = new KeyBindingDefinition(
+            "kbd_editor_SelectAttachedCurves",
+             ModifierKeys.Shift, Key.V);
+
+        [Export]
         //        [Gesture Ctrl+C]=[Action MenuItemAction_CopySelectedObjects];
         public static KeyBindingDefinition KBD_CopySelectedObjects = new KeyBindingDefinition(
             "kbd_editor_CopySelectedObjects",

--- a/OngekiFumenEditor/Modules/FumenVisualEditor/ViewModels/FumenVisualEditorViewModel.UserInteractionActions.cs
+++ b/OngekiFumenEditor/Modules/FumenVisualEditor/ViewModels/FumenVisualEditorViewModel.UserInteractionActions.cs
@@ -194,6 +194,7 @@ namespace OngekiFumenEditor.Modules.FumenVisualEditor.ViewModels
         {
             foreach (var connectable in SelectObjects.OfType<ConnectableObjectBase>().Select(c => c.ReferenceStartObject).Distinct())
             {
+                connectable.IsSelected = true;
                 foreach (var child in connectable.Children)
                 {
                     child.IsSelected = true;

--- a/OngekiFumenEditor/Modules/FumenVisualEditor/Views/FumenVisualEditorView.xaml
+++ b/OngekiFumenEditor/Modules/FumenVisualEditor/Views/FumenVisualEditorView.xaml
@@ -35,6 +35,7 @@
             <valueconverters:ReverseBoolConverter x:Key="ReverseBoolConverter" />
             <converters:BoolToScrollBarVisibleConverter x:Key="BoolToScrollBarVisibleConverter" />
             <converters:IsStringEmptyConverter x:Key="IsStringEmptyConverter" />
+            <converters:KeyBindingToTextConverter x:Key="KeyBindingToTextConverter" />
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -56,6 +57,8 @@
         <kb:ActionMessageKeyBinding Definition="{x:Static kbDefs:KeyBindingDefinitions.KBD_ToggleBatchMode}" Message="KeyboardAction_ToggleBatchMode($executionContext)" />
         <kb:ActionMessageKeyBinding Definition="{x:Static kbDefs:KeyBindingDefinitions.KBD_FastAddConnectableChild}" Message="KeyboardAction_FastAddConnectableChild($executionContext)" />
         <kb:ActionMessageKeyBinding Definition="{x:Static kbDefs:KeyBindingDefinitions.KBD_FastSwitchFlickDirection}" Message="KeyboardAction_FastSwitchFlickDirection($executionContext)" />
+        <kb:ActionMessageKeyBinding Definition="{x:Static kbDefs:KeyBindingDefinitions.KBD_SelectEntireLane}" Message="MenuItemAction_SelectEntireLane($executionContext)" />
+        <kb:ActionMessageKeyBinding Definition="{x:Static kbDefs:KeyBindingDefinitions.KBD_SelectAttachedCurves}" Message="MenuItemAction_SelectAttachedCurves($executionContext)" />
         <kb:ActionMessageKeyBinding Definition="{x:Static kbDefs:KeyBindingDefinitions.KBD_CopySelectedObjects}" Message="MenuItemAction_CopySelectedObjects($executionContext)" />
         <kb:ActionMessageKeyBinding Definition="{x:Static kbDefs:KeyBindingDefinitions.KBD_PasteCopiesObjects}" Message="KeyboardAction_PasteCopiesObjects($executionContext)" />
         <kb:ActionMessageKeyBinding Definition="{x:Static kbDefs:KeyBindingDefinitions.KBD_ScrollPageDown}" Message="ScrollPage(-1)" />
@@ -79,11 +82,13 @@
             <ContextMenu x:Name="EditorContextMenu">
                 <MenuItem Header="{markup:Translate [MenuSelecting]}">
                     <MenuItem Header="Entire lane"
+                              InputGestureText="{Binding Source={x:Static kbDefs:KeyBindingDefinitions.KBD_SelectEntireLane}, Converter={StaticResource KeyBindingToTextConverter}}"
                               cal:Message.Attach="MenuItemAction_SelectEntireLane($executionContext)"
                               IsEnabled="{Binding SelectObjects, Converter={StaticResource SelectionLaneObjectsCheckConverter}}" />
                     <MenuItem Header="Attached curve points"
-                        cal:Message.Attach="MenuItemAction_SelectAttachedCurves($executionContext)"
-                        IsEnabled="{Binding SelectObjects, Converter={StaticResource SelectionLaneObjectsCheckConverter}}" />
+                              InputGestureText="{Binding Source={x:Static kbDefs:KeyBindingDefinitions.KBD_SelectAttachedCurves}, Converter={StaticResource KeyBindingToTextConverter}}"
+                              cal:Message.Attach="MenuItemAction_SelectAttachedCurves($executionContext)"
+                              IsEnabled="{Binding SelectObjects, Converter={StaticResource SelectionLaneObjectsCheckConverter}}" />
                     <Separator />
                     <MenuItem cal:Message.Attach="MenuItemAction_SelectAll($executionContext)" Header="{markup:Translate [SelectAllObjects]}" />
                     <MenuItem cal:Message.Attach="MenuItemAction_ReverseSelect($executionContext)" Header="{markup:Translate [ReverseSelectAllObjects]}" />

--- a/OngekiFumenEditor/Properties/Resources.Designer.cs
+++ b/OngekiFumenEditor/Properties/Resources.Designer.cs
@@ -3722,7 +3722,25 @@ namespace OngekiFumenEditor.Properties {
                 return ResourceManager.GetString("kbd_editor_FastSwitchFlickDirection", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   查找类似 Select attached curve control points 的本地化字符串。
+        /// </summary>
+        public static string kbd_editor_SelectAttachedCurves {
+            get {
+                return ResourceManager.GetString("kbd_editor_SelectAttachedCurves", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Select entire lane 的本地化字符串。
+        /// </summary>
+        public static string kbd_editor_SelectEntireLane {
+            get {
+                return ResourceManager.GetString("kbd_editor_SelectEntireLane", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Toggle display mode 的本地化字符串。
         /// </summary>

--- a/OngekiFumenEditor/Properties/Resources.resx
+++ b/OngekiFumenEditor/Properties/Resources.resx
@@ -1794,6 +1794,12 @@
   <data name="kbd_editor_FastSwitchFlickDirection" xml:space="preserve">
     <value>Switch directions of selected flicks</value>
   </data>
+  <data name="kbd_editor_SelectEntireLane" xml:space="preserve">
+    <value>Select entire lane</value>
+  </data>
+  <data name="kbd_editor_SelectAttachedCurves" xml:space="preserve">
+    <value>Select attached curve control points</value>
+  </data>
   <data name="kbd_editor_CopySelectedObjects" xml:space="preserve">
     <value>Copy selection to clipboard</value>
   </data>


### PR DESCRIPTION
* Fix "Select > select entire lane" to include start node
* Add keybinds for "Select > select entire lane" (Shift+E) and "Select > select attached curve points" (Shift+V)