### PR TITLE
editor: fix typo in play crash fix

### DIFF
--- a/OngekiFumenEditor/Modules/OngekiGamePlayControllerViewer/ViewModels/OngekiGamePlayControllerViewerViewModel.cs
+++ b/OngekiFumenEditor/Modules/OngekiGamePlayControllerViewer/ViewModels/OngekiGamePlayControllerViewerViewModel.cs
@@ -402,7 +402,7 @@ namespace OngekiFumenEditor.Modules.OngekiGamePlayControllerViewer.ViewModels
 
         public async Task<bool> IsPlaying()
         {
-            if (ConnectStatus != ConnectStatus.Disconnected)
+            if (ConnectStatus != ConnectStatus.Connected)
                 return false;
 
             var play = await RequestRemoteService<IPlayingRpcService>();


### PR DESCRIPTION
I looked at #36 and realized I didn't actually fix the bug because I was checking the wrong enum value 😭 Sorry!