### PR TITLE
Force CWD to program dir when running CLI

### DIFF
--- a/OngekiFumenEditor.CommandLine/Program.cs
+++ b/OngekiFumenEditor.CommandLine/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Reflection;
 
 namespace OngekiFumenEditor.CommandLine
@@ -8,6 +9,8 @@ namespace OngekiFumenEditor.CommandLine
         [STAThread]
         static int Main(string[] args)
         {
+            Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
+
             Assembly assembly;
             try
             {


### PR DESCRIPTION
Due to how Gemini loads assemblies, the CLI will often crash if your current directory has any subdirectories containing `Assembly-CSharp.dll` files (see https://github.com/NyagekiFumenProject/gemini/blob/1147123f3506e531e71f940f1765d28825f28ae5/src/Gemini/AppBootstrapper.cs#L98). This is undesirable for a CLI which could be called by scripts from other directories.

The CLI already requires all given paths to be absolute, so this won't have any user-facing impact.