### PR TITLE
Fix crash when refreshing fumen list with empty/invalid root folder

### DIFF
--- a/OngekiFumenEditor/Modules/OgkiFumenListBrowser/ViewModels/OgkiFumenListBrowserViewModel.cs
+++ b/OngekiFumenEditor/Modules/OgkiFumenListBrowser/ViewModels/OgkiFumenListBrowserViewModel.cs
@@ -79,9 +79,13 @@ namespace OngekiFumenEditor.Modules.OgkiFumenListBrowser.ViewModels
 
         private async void RefreshList()
         {
-            IsBusy = true;
             fumenSets.Clear();
             DisplayFumenSets.Clear();
+
+            if (!Directory.Exists(RootFolderPath))
+                return;
+
+            IsBusy = true;
 
             var folder = await SearchFumenSet(RootFolderPath);
 


### PR DESCRIPTION
The RootFolderPath setter unconditionally called RefreshList(), which reached Directory.GetDirectories() with an empty path when the folder was unset or invalid, throwing an unhandled ArgumentException on the Dispatcher. Guard RefreshList() with Directory.Exists() (matching OnViewLoaded) so the setter, constructor, and user edits are all safe.